### PR TITLE
修复：日程表不自动展开的问题

### DIFF
--- a/src/data/_agenda.yaml
+++ b/src/data/_agenda.yaml
@@ -997,7 +997,7 @@ shanghai:
                 Open Source.<br />Tutorial Content<br />PyCon Debugging Tutorial:
                 https://github.com/gloveboxes/PyCon-Hands-on-Lab'
             slides: '#'
-    actived: actived
+    actived: active
 beijing:
     city: beijing
     name: 北京


### PR DESCRIPTION
其实是一个Typo。重新生成一下即可。脚本中已修正。